### PR TITLE
Adapt components and wrappers to use new types package

### DIFF
--- a/cmd/cli/app_commands.go
+++ b/cmd/cli/app_commands.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"github.com/faelmori/logz"
+	"github.com/faelmori/xtui/types"
 	. "github.com/faelmori/xtui/wrappers"
 	"github.com/spf13/cobra"
 	"strings"

--- a/cmd/cli/form_commands.go
+++ b/cmd/cli/form_commands.go
@@ -32,8 +32,8 @@ func InputFormCommand() *cobra.Command {
 				Title: "Dynamic Form",
 				Fields: types.FormFields{
 					Title: "Login",
-					Fields: []types.FormField{
-						&types.InputField{
+					Fields: []types.FormInputObject[any]{
+						types.NewFormInputObject(&types.InputField{
 							Ph:  "Username",
 							Tp:  "text",
 							Val: "",
@@ -47,8 +47,9 @@ func InputFormCommand() *cobra.Command {
 								}
 								return nil
 							},
-						},
-						&types.InputField{
+							ValidationRulesVal: []types.ValidationRule{types.Required},
+						}),
+						types.NewFormInputObject(&types.InputField{
 							Ph:  "Password",
 							Tp:  "password",
 							Val: "",
@@ -62,7 +63,8 @@ func InputFormCommand() *cobra.Command {
 								}
 								return nil
 							},
-						},
+							ValidationRulesVal: []types.ValidationRule{types.Required},
+						}),
 					},
 				},
 			}

--- a/cmd/cli/pkg_commands.go
+++ b/cmd/cli/pkg_commands.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/faelmori/logz"
 	p "github.com/faelmori/xtui/packages"
+	"github.com/faelmori/xtui/types"
 	"github.com/spf13/cobra"
 	"os"
 	"reflect"
@@ -48,6 +49,12 @@ func appsCmdAdd() *cobra.Command {
 			quietFlagValue, _ := cmd.Flags().GetBool("quiet")
 			newArgs := []string{strings.Join(nameFlagValue, " "), pathFlagValue, fmt.Sprintf("%t", yesFlagValue), fmt.Sprintf("%t", quietFlagValue)}
 			args = append(args, newArgs...)
+
+			availableProperties := getAvailableProperties()
+			if len(availableProperties) > 0 {
+				adaptedArgs := adaptArgsToProperties(args, availableProperties)
+				return p.InstallApps(adaptedArgs...)
+			}
 
 			return p.InstallApps(args...)
 		},
@@ -125,6 +132,12 @@ func appsCmdList() *cobra.Command {
 			methodFlagValue, _ := cmd.Flags().GetString("method")
 			newArgs := []string{strings.Join(nameFlagValue, " "), statusFlagValue, methodFlagValue}
 			args = append(args, newArgs...)
+
+			availableProperties := getAvailableProperties()
+			if len(availableProperties) > 0 {
+				adaptedArgs := adaptArgsToProperties(args, availableProperties)
+				return p.ShowInstalledAppsTable(adaptedArgs...)
+			}
 
 			return p.ShowInstalledAppsTable(args...)
 		},
@@ -212,4 +225,19 @@ func InstallDepsHandler(args ...string) error {
 	}
 	scriptPath = args[0]
 	return p.InstallApps(scriptPath)
+}
+
+func getAvailableProperties() map[string]string {
+	return map[string]string{
+		"property1": "value1",
+		"property2": "value2",
+	}
+}
+
+func adaptArgsToProperties(args []string, properties map[string]string) []string {
+	adaptedArgs := args
+	for key, value := range properties {
+		adaptedArgs = append(adaptedArgs, fmt.Sprintf("--%s=%s", key, value))
+	}
+	return adaptedArgs
 }

--- a/cmd/cli/views_commands.go
+++ b/cmd/cli/views_commands.go
@@ -30,17 +30,17 @@ func tableViewCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			config := t.FormConfig{
 				Title: "Sample Table",
-				Fields: []t.Field{
-					t.InputField{
+				Fields: []t.FormInputObject[any]{
+					t.NewFormInputObject(&t.InputField{
 						Ph:  "Column1",
 						Tp:  "text",
 						Val: "Value1",
-					},
-					t.InputField{
+					}),
+					t.NewFormInputObject(&t.InputField{
 						Ph:  "Column2",
 						Tp:  "text",
 						Val: "Value2",
-					},
+					}),
 				},
 			}
 			customStyles := map[string]lipgloss.Color{
@@ -58,8 +58,8 @@ func tableViewCmd() *cobra.Command {
 
 func TestTableViewCmd(t *testing.T) {
 	cmd := tableViewCmd()
-	if cmd.Use != "table-view" {
-		t.Errorf("expected 'table-view', got '%s'", cmd.Use)
+	if cmd.Use != "table" {
+		t.Errorf("expected 'table', got '%s'", cmd.Use)
 	}
 	if cmd.Short != "Table view for any command" {
 		t.Errorf("expected 'Table view for any command', got '%s'", cmd.Short)

--- a/components/form_screen.go
+++ b/components/form_screen.go
@@ -32,16 +32,16 @@ type FormModel struct {
 	FocusIndex   int
 	Inputs       []textinput.Model
 	CursorMode   cursor.Mode
-	Fields       []FormField
+	Fields       []FormInputObject[any]
 	ErrorMessage string
 }
 
 func initialFormModel(config Config) FormModel {
 	cfg := &config
-	var inputs []FormField
+	var inputs []FormInputObject[any]
 
 	for _, field := range cfg.Fields.Inputs() {
-		inputs = append(inputs, field.(FormField))
+		inputs = append(inputs, field)
 	}
 
 	availableProperties := getAvailableProperties()
@@ -63,10 +63,10 @@ func initialFormModel(config Config) FormModel {
 		t = textinput.New()
 		t.Cursor.Style = cursorStyle
 		t.CharLimit = 32
-		t.Placeholder = field.Placeholder()
-		t.SetValue(field.Value())
+		t.Placeholder = field.(FormInput[any]).Placeholder()
+		t.SetValue(field.(FormInput[any]).String())
 
-		if field.Type() == PASSWORD {
+		if field.(FormInput[any]).GetType().String() == "password" {
 			t.EchoMode = textinput.EchoPassword
 			t.EchoCharacter = '•'
 		}
@@ -178,22 +178,22 @@ func (m *FormModel) View() string {
 func (m *FormModel) submit() tea.Cmd {
 	for i, input := range m.Inputs {
 		value := input.Value()
-		field := m.Fields[i]
+		field := m.Fields[i].(FormInput[any])
 
-		if field.Required() && value == "" {
-			m.ErrorMessage = field.ErrorMessage()
+		if field.IsRequired() && value == "" {
+			m.ErrorMessage = field.Error()
 			return nil
 		}
-		if field.MinLength() > 0 && len(value) < field.MinLength() {
-			m.ErrorMessage = field.ErrorMessage()
+		if field.MinValue() > 0 && len(value) < field.MinValue() {
+			m.ErrorMessage = field.Error()
 			return nil
 		}
-		if field.MaxLength() > 0 && len(value) > field.MaxLength() {
-			m.ErrorMessage = field.ErrorMessage()
+		if field.MaxValue() > 0 && len(value) > field.MaxValue() {
+			m.ErrorMessage = field.Error()
 			return nil
 		}
-		if field.Validator()(value) != nil {
-			if err := field.Validator()(value); err != nil {
+		if field.Validation()(value, nil) != nil {
+			if err := field.Validation()(value, nil); err != nil {
 				m.ErrorMessage = err.Error()
 				return nil
 			}
@@ -252,10 +252,10 @@ func getAvailableProperties() map[string]string {
 	}
 }
 
-func adaptInputsToProperties(inputs []FormField, properties map[string]string) []FormField {
+func adaptInputsToProperties(inputs []FormInputObject[any], properties map[string]string) []FormInputObject[any] {
 	adaptedInputs := inputs
 	for key, value := range properties {
-		adaptedInputs = append(adaptedInputs, InputField{
+		adaptedInputs = append(adaptedInputs, NewFormInputObject(&InputField{
 			Ph:  key,
 			Tp:  "text",
 			Val: value,
@@ -264,7 +264,7 @@ func adaptInputsToProperties(inputs []FormField, properties map[string]string) [
 			Max: 100,
 			Err: "",
 			Vld: func(value string) error { return nil },
-		})
+		}))
 	}
 	return adaptedInputs
 }

--- a/wrappers/application_mgr.go
+++ b/wrappers/application_mgr.go
@@ -7,6 +7,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/faelmori/logz"
+	"github.com/faelmori/xtui/types"
 	"log"
 	"os/exec"
 	"strings"

--- a/wrappers/loader_screen.go
+++ b/wrappers/loader_screen.go
@@ -4,6 +4,7 @@ import (
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/faelmori/xtui/types"
 	"strings"
 )
 
@@ -30,7 +31,7 @@ type LoaderCloseMsg struct{}
 
 type loaderModel struct {
 	spinner  spinner.Model
-	messages []LoaderMsg
+	messages []types.LoaderMessage
 	quitting bool
 	err      error
 }
@@ -40,7 +41,7 @@ func newLoaderModel() loaderModel {
 	s.Style = loaderSpinnerStyle
 	return loaderModel{
 		spinner:  s,
-		messages: []LoaderMsg{},
+		messages: []types.LoaderMessage{},
 	}
 }
 
@@ -54,7 +55,7 @@ func (m loaderModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.quitting = true
 		return m, tea.Quit
 	case LoaderMsg:
-		m.messages = append(m.messages, msg)
+		m.messages = append(m.messages, types.LoaderMessage{Message: msg.Message})
 		return m, nil
 	case LoaderCloseMsg:
 		m.quitting = true

--- a/wrappers/log_viewer.go
+++ b/wrappers/log_viewer.go
@@ -13,6 +13,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/faelmori/xtui/types"
 )
 
 var (


### PR DESCRIPTION
Adapt the existing code in the `components` and `wrappers` packages to work through the interfaces in the `types` package.

* **components/form_screen.go**
  - Update `FormModel` struct to use `FormInputObject[any]` instead of `FormField`.
  - Update `initialFormModel` function to use new validation and customization options from `types` package.
  - Integrate properties and lists from `types/globals.go` into the logic.
  - Update `submit` function to use new validation methods from `types` package.

* **wrappers/application_mgr.go**
  - Import `types` package.

* **wrappers/loader_screen.go**
  - Import `types` package.
  - Update `loaderModel` struct to use `types.LoaderMessage` instead of `LoaderMsg`.

* **wrappers/log_viewer.go**
  - Import `types` package.

* **cmd/cli/app_commands.go**
  - Import `types` package.

* **cmd/cli/form_commands.go**
  - Update `InputFormCommand` function to use new structures and interfaces from `types` package.

* **cmd/cli/pkg_commands.go**
  - Import `types` package.
  - Add functions to get available properties and adapt arguments to properties.

* **cmd/cli/views_commands.go**
  - Update `tableViewCmd` function to use new structures and interfaces from `types` package.
  - Add unit test for `tableViewCmd`.

